### PR TITLE
Change check for compiling errors. Closes #52 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test:
 	pytest
 
 check:
-	python main.py
+	python -m compileall ./src/
 
 install:
 	pip install -r requirements.txt

--- a/main.py
+++ b/main.py
@@ -1,7 +1,0 @@
-from src.entities.exercise import *
-from src.entities.routine import *
-from src.entities.user import *
-
-
-def __main__():
-    pass


### PR DESCRIPTION
- Remove main.py from root directory
- Use python -m compileall ./src/ instead to check for compiling errors

Closes #52 